### PR TITLE
Adding HTTPS format to "correct_urls" variable

### DIFF
--- a/packages/movie_names.py
+++ b/packages/movie_names.py
@@ -8,7 +8,7 @@ def get_movie_from_url(link_set: List) -> List:
 	returns the sorted movie names accordingly.
 	"""
 
-	correct_urls = ["http://swapi.dev/api/films/1/", "http://swapi.dev/api/films/2/", "http://swapi.dev/api/films/3/", "http://swapi.dev/api/films/4/", "http://swapi.dev/api/films/5/", "http://swapi.dev/api/films/6/"]
+	correct_urls = ["https://swapi.dev/api/films/1/", "https://swapi.dev/api/films/2/", "https://swapi.dev/api/films/3/", "https://swapi.dev/api/films/4/", "https://swapi.dev/api/films/5/", "https://swapi.dev/api/films/6/"]
 
 	# Checking for incorrect elements on list:
 


### PR DESCRIPTION
This fixes the following error:

---------------------------------------------------------------------------
SystemExit                                Traceback (most recent call last)
/tmp/ipykernel_71/823389663.py in <module>
      3 character2 = input("Input the second character: ")
      4 
----> 5 lambda_swapi_func(character1, character2)

~/packages/lambda_swapi.py in lambda_swapi_func(first_char, second_char)
     20                 return set_results
     21         else:
---> 22                 cleaned_results = get_movie_from_url(set_results)
     23                 print("\n|RESULT| -> The selected characters share these movies:")
     24                 return cleaned_results

~/packages/movie_names.py in get_movie_from_url(link_set)
     15         for url in link_set:
     16                 if url not in correct_urls:
---> 17                         raise SystemExit("|ERROR| -> Wrong URL on list.")
     18 
     19         if (len(link_set) > 6) \

SystemExit: |ERROR| -> Wrong URL on list.